### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Installing
 
-**Cocoapods**
+**CocoaPods**
 
 `pod 'BTCDonationViewController'`
 
@@ -77,11 +77,11 @@ There is no native iPad support, so an iPad ViewController version of this shoul
 
 ## Demo
 
-There is a demo project included in this repo. To run it, make sure you have [Cocoapods](http://cocoapods.org/) installed on your machine. Navigate to the directory of the demo project, and run this line in your Terminal:
+There is a demo project included in this repo. To run it, make sure you have [CocoaPods](http://cocoapods.org/) installed on your machine. Navigate to the directory of the demo project, and run this line in your Terminal:
 
 `pod install`
 
-This will set up your project with Cocoapods, install the prerequisites, and then create a `.xcworkspace` file that you will use to build and run the demo.
+This will set up your project with CocoaPods, install the prerequisites, and then create a `.xcworkspace` file that you will use to build and run the demo.
 
 ## License
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
